### PR TITLE
update sbom release file

### DIFF
--- a/.github/workflows/add-sbom-to-release.yaml
+++ b/.github/workflows/add-sbom-to-release.yaml
@@ -41,4 +41,4 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          files: priv/static/.well-known/sbom/*
+          files: priv/static/.well-known/sbom/twinkly*


### PR DESCRIPTION
Update the SBOM release  to only include the twinklyhaha SBOM file and exclude the gitkeep when generating assets