### PR TITLE
fix select down  down option to stop collapsing when user select rainbow

### DIFF
--- a/lib/twinklyhaha_web/live/twinkly_live.ex
+++ b/lib/twinklyhaha_web/live/twinkly_live.ex
@@ -24,7 +24,7 @@ defmodule TwinklyhahaWeb.TwinklyLive do
         <%= for row <- 0..7 do %>
           <%= for column <- 0..7 do %>
             <div class="led-box">
-            <div class={["led", "led-#{if @led_on?, do: "on", else: "off"}"]} id={"led-#{row}#{column}"} 
+            <div class={["led", "led-#{if @led_on?, do: "on", else: "off"}"]} id={"led-#{row}#{column}"}
                 data-ledcolor={if @current_color == "rainbow", do: Stream.cycle(@colors) |> Enum.at(row), else: @current_color} phx-hook="LedColor"></div>
             </div>
           <% end %>
@@ -40,10 +40,12 @@ defmodule TwinklyhahaWeb.TwinklyLive do
   end
 
   defp select_color(assigns) do
+    assigns = assign(assigns, select_drop_down_colours: @colors)
+
     ~H"""
     <form phx-change="change-color">
       <select id="select-colors" name="color">
-      <%= for color <- @colors do %>
+      <%= for color <- @select_drop_down_colours do %>
           <option value={color} selected={if @current_color == color, do: "selected"}  >
             <%= color %>
           </option>


### PR DESCRIPTION
## Related Issue
See #203 

## Task
- On the twinky, when the LED is on, and the user selects the rainbow option,  the select drop down down/up collapses, and the user is not able to select another color.
-
- The options(colours) passed on the select dropdown are the same as the colours twinkling on Twinkie. This means when the user selects rainbow, we stream all colours and keep changing fast to give the illusion of a rainbow. This means the select options change, at the same time as the other colors of the rainbow.

## Change
-  The fix is assigning the select options a variable that does not change.

### Before 
[Screencast from 2026-03-18 18-49-39.webm](https://github.com/user-attachments/assets/28b2e616-6906-498d-8367-a78945585151)

### After the fix
[Screencast from 2026-03-18 18-52-42.webm](https://github.com/user-attachments/assets/2b57b670-4d38-4792-9b6d-fc6b0d32e172)
